### PR TITLE
Adding builds for dbus-python

### DIFF
--- a/packages/dbus-python/Dockerfile-3.4
+++ b/packages/dbus-python/Dockerfile-3.4
@@ -1,0 +1,12 @@
+FROM imrehg/armv7hf-python:3.4
+
+VOLUME /usr/src/target
+
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends \
+      libdbus-1-dev \
+      libdbus-glib-1-dev
+
+COPY payload.sh ./
+
+ENTRYPOINT ["bash", "payload.sh"]

--- a/packages/dbus-python/Dockerfile-3.5
+++ b/packages/dbus-python/Dockerfile-3.5
@@ -1,0 +1,12 @@
+FROM imrehg/armv7hf-python:3.5
+
+VOLUME /usr/src/target
+
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends \
+      libdbus-1-dev \
+      libdbus-glib-1-dev
+
+COPY payload.sh ./
+
+ENTRYPOINT ["bash", "payload.sh"]

--- a/packages/dbus-python/Dockerfile-3.6
+++ b/packages/dbus-python/Dockerfile-3.6
@@ -1,0 +1,12 @@
+FROM imrehg/armv7hf-python:3.6
+
+VOLUME /usr/src/target
+
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends \
+      libdbus-1-dev \
+      libdbus-glib-1-dev
+
+COPY payload.sh ./
+
+ENTRYPOINT ["bash", "payload.sh"]

--- a/packages/dbus-python/build.sh
+++ b/packages/dbus-python/build.sh
@@ -1,0 +1,4 @@
+versions="3.4 3.5 3.6"
+for version in $versions; do
+  docker build . -f Dockerfile-${version} -t imrehg/armv7hf-python-dbus-python:${version}
+done

--- a/packages/dbus-python/cross-all.sh
+++ b/packages/dbus-python/cross-all.sh
@@ -1,0 +1,8 @@
+pythons="3.4 3.5 3.6"
+for python in $pythons; do
+ docker run \
+  --rm \
+  --detach \
+  -v $PWD/target:/usr/src/target \
+  imrehg/armv7hf-python-dbus-python:$python $1
+done

--- a/packages/dbus-python/cross.sh
+++ b/packages/dbus-python/cross.sh
@@ -2,4 +2,4 @@ docker run \
   --rm \
   --detach \
   -v $PWD/target:/usr/src/target \
-  imrehg/armv7hf-python-numpy:$1 $2
+  imrehg/armv7hf-python-dbus-python:$1 $2

--- a/packages/dbus-python/cross.sh
+++ b/packages/dbus-python/cross.sh
@@ -1,0 +1,5 @@
+docker run \
+  --rm \
+  --detach \
+  -v $PWD/target:/usr/src/target \
+  imrehg/armv7hf-python-numpy:$1 $2

--- a/packages/dbus-python/payload.sh
+++ b/packages/dbus-python/payload.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+PKG=$1
+TARGET=/usr/src/target
+TMP=/tmp
+
+pip wheel -vvv --wheel-dir ${TMP} ${PKG}
+for f in ${TMP}/*linux*.whl; do
+	auditwheel repair --wheel-dir=${TARGET} ${f}
+done


### PR DESCRIPTION
Added a folder to help build [dbus-python](https://pypi.org/project/dbus-python/) as it would not build with the generic build due to dependencies on libdbus-1-dev and libdbus-glib-1-dev.